### PR TITLE
Add image_tag to Attendee#index view

### DIFF
--- a/attendee_tutorial.md
+++ b/attendee_tutorial.md
@@ -137,6 +137,14 @@ to
 
     <%= image_tag(@attendee.picture_url, :width => 600) if @attendee.picture.present? %>
 
+Open `app/views/attendees/index.html.erb` and change
+
+    <td><%= attendee.picture %></td>
+
+to
+
+    <td><%= image_tag(attendee.picture_url, :width => 100) if attendee.picture.present? %></td>
+
 Now refresh your browser to see what changed.
 
 <span class="lead coach"><i class="icon-comment-alt"> Coach</i>: Talk a little about HTML.</span>


### PR DESCRIPTION
I noticed that the image_tag has been added to Attendee#show, but not
yet to Attendee#index, causing the application to display just the
value of the picture attribute (e.g. the path where the uploaded file
is stored) instead of the image itself in the Attendee#index view.

As the page with the map will look much fancier with the users pictures,
I added image_tag there, too.
