### PR TITLE
Updating #6: Add Geolocator and Google Maps

### DIFF
--- a/attendee_tutorial.md
+++ b/attendee_tutorial.md
@@ -77,7 +77,7 @@ Now let’s also change the styling. Open `app/assets/stylesheets/application.cs
 
     body { padding-top: 100px; }
     footer { margin-top: 100px; }
-    #map { width: 800px; height: 400px; margin: 30px; }
+    #map { width: 800px; height: 400px; margin: 30px 0; }
 
 Now make sure you saved your files and refresh the browser to see what was changed. You can also change the HTML & CSS further.
 
@@ -218,13 +218,11 @@ Add in **app/views/attendees/index.html.erb**
 
         for (var i = 0, l = attendees.length; i < l; i++) {
           var position = new google.maps.LatLng(attendees[i].latitude, attendees[i].longitude);
-
           new google.maps.Marker({
             position: position,
             map     : map,
             title   : attendees[i].name
           });
-
           markerBounds.extend(position);
         }
 

--- a/attendee_tutorial.md
+++ b/attendee_tutorial.md
@@ -210,26 +210,28 @@ Add in **app/views/attendees/index.html.erb**
     <script type="text/javascript">
       function initialize() {
         var attendees    = <%= raw @attendees.to_json %>;
-        var map          = new google.maps.Map(document.getElementById('map'), {});
+        var map          = new google.maps.Map(document.getElementById('map'), {
+          zoom  : 4,
+          center: new google.maps.LatLng(52.519242, 13.404169) // Berlin
+        });
         var markerBounds = new google.maps.LatLngBounds();
 
         for (var i = 0, l = attendees.length; i < l; i++) {
           var position = new google.maps.LatLng(attendees[i].latitude, attendees[i].longitude);
+
           new google.maps.Marker({
             position: position,
             map     : map,
             title   : attendees[i].name
           });
+
           markerBounds.extend(position);
         }
 
-        map.setCenter(markerBounds.getCenter());
-        if (attendees.length <= 1) {
-          map.setZoom(4);
-        } else {
-          map.fitBounds(markerBounds);
-        }
+        if (attendees.length > 0) map.setCenter(markerBounds.getCenter());
+        if (attendees.length > 1) map.fitBounds(markerBounds);
       }
+
       google.maps.event.addDomListener(window, 'load', initialize);
     </script>
 


### PR DESCRIPTION
By adding a few extra lines of JavaScript we can avoid using the `gmaps4rails` gem and especially `underscore.js` which is slightly painful to download and include while it’s really only (visibly) used in one single location anyway.

I’ve also rewritten the JavaScript to be more explicit so coaches may even be able to walk an attendee through it if they chose to do so.

The rest of the instructions have been updated to reflect this change.
